### PR TITLE
Combability for paygw_bank plugin

### DIFF
--- a/classes/payment/service_provider.php
+++ b/classes/payment/service_provider.php
@@ -50,6 +50,22 @@ class service_provider implements \core_payment\local\callback\service_provider 
         // Get the fake item in case of topping up the wallet.
         $item = $DB->get_record('enrol_wallet_items', ['id' => $itemid], '*', MUST_EXIST);
 
+        if (!$item) {
+            // If the item is not found in enrol_wallet_items, try to get it from paygw_bank
+            $bankitem = $DB->get_record('paygw_bank', ['itemid' => $itemid], '*', IGNORE_MISSING);
+            if (!$bankitem) {
+                // If both records are missing, return a default payable object
+                $defaultcost = 0;
+                $defaultcurrency = get_config('moodle', 'currency');
+                $defaultaccount = get_config('enrol_wallet', 'paymentaccount');
+                return new \core_payment\local\entities\payable($defaultcost, $defaultcurrency, $defaultaccount);
+            }
+            $item = new \stdClass();
+            $item->cost = $bankitem->totalamount;
+            $item->currency = $bankitem->currency;
+            $item->instanceid = $bankitem->itemid;
+        }
+
         // In this case we get the default settings.
         if ($paymentarea === 'walletenrol') {
             $account = $DB->get_field('enrol', 'customint1', ['id' => $item->instanceid]);
@@ -70,6 +86,9 @@ class service_provider implements \core_payment\local\callback\service_provider 
     public static function get_success_url(string $paymentarea, int $itemid): \moodle_url {
         global $DB;
         $item = $DB->get_record('enrol_wallet_items', ['id' => $itemid], '*', IGNORE_MISSING);
+        if (!$item) {
+            $item = $DB->get_record('paygw_bank', ['itemid' => $itemid], '*', IGNORE_MISSING);
+        }
         // Check if the payment is for enrolment or topping up the wallet.
         if ($paymentarea == 'walletenrol' && !empty($item->instanceid)) {
 
@@ -80,6 +99,7 @@ class service_provider implements \core_payment\local\callback\service_provider 
         } else {
 
             return new \moodle_url('/');
+
         }
     }
 
@@ -97,7 +117,14 @@ class service_provider implements \core_payment\local\callback\service_provider 
 
         require_once($CFG->dirroot.'/enrol/wallet/lib.php');
         // Get the fake item in case of topping up the wallet.
-        $item = $DB->get_record('enrol_wallet_items', ['id' => $itemid], '*', MUST_EXIST);
+        $item = $DB->get_record('enrol_wallet_items', ['id' => $itemid], '*', IGNORE_MISSING);
+        if (!$item) {
+            $item = $DB->get_record('paygw_bank', ['itemid' => $itemid], '*', IGNORE_MISSING);
+            if (!$item) {
+                return false;
+            }
+            $item->cost = $item->totalamount;
+        }
         $op = new op($userid, $item->category ?? 0);
 
         $coststring = \core_payment\helper::get_cost_as_string($item->cost, $item->currency);
@@ -132,14 +159,8 @@ class service_provider implements \core_payment\local\callback\service_provider 
             return false;
 
         } else {
-
             $response = $op->credit($item->cost, op::C_PAYMENT, $itemid, $desc);
-
-            if ($response) {
-                return true;
-            } else {
-                return false;
-            }
+            return $response;
         }
     }
 }

--- a/classes/payment/service_provider.php
+++ b/classes/payment/service_provider.php
@@ -160,7 +160,12 @@ class service_provider implements \core_payment\local\callback\service_provider 
 
         } else {
             $response = $op->credit($item->cost, op::C_PAYMENT, $itemid, $desc);
-            return $response;
+
+            if ($response) {
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds combability to [unesco-iesalc/paygw_bank](https://github.com/unesco-iesalc/paygw_bank) plugin.

The wallet plugin was throwing an exception when trying to retrieve payment information for (bank9 transactions that were no longer present in the enrol_wallet_items table. This table is used for temporary storage of payment information, but the records are deleted after a certain period. When the bank payment gateway tried to access this information later (e.g., for approval or management purposes), it would fail if the record had been deleted.

**Issue:**

The wallet plugin was throwing an exception when trying to retrieve payment information for transactions that were no longer present in the enrol_wallet_items table when using paygt_bank plugin. This table is used for temporary storage of payment information, but the records are deleted after a certain period. When the bank payment gateway tried to access this information later (e.g., for approval of bank slip or management purposes), it would fail if the record had been deleted.

**Error I saw was:**

```
2024/09/21 14:08:14 [error] 2300968#2300968: *642387 FastCGI sent in stderr: "PHP message: Default exception handler: Data records for table enrol_wallet_items were not found. Debug: SELECT * FROM {enrol_wallet_items} WHERE id = ?
[array (
  0 => 17,
)]
Error code: invalidrecord
* line 1659 of /lib/dml/moodle_database.php: dml_missing_record_exception thrown
* line 1635 of /lib/dml/moodle_database.php: call to moodle_database->get_record_select()
* line 51 of /enrol/wallet/classes/payment/service_provider.php: call to moodle_database->get_record()
* line 7825 of /lib/moodlelib.php: call to enrol_wallet\payment\service_provider::get_payable()
* line 200 of /payment/classes/helper.php: call to component_class_callback()
* line 228 of /payment/classes/helper.php: call to core_payment\helper::get_payable()
* line 109 of /payment/gateway/bank/manage.php: call to core_payment\helper::get_gateway_configuration()" while reading upstream, client: 93.180.98.98, server: my_server, request: "GET /payment/gateway/bank/manage.php HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.1-fpm-my_server.sock:", host: "my_server"
```

**Changes:**

1: I modified the get_payable method in the service_provider.php file to handle cases where the payment record is missing from both the enrol_wallet_items and paygw_bank tables. Instead of throwing an exception, it now returns a default payable object.

**Code changes in enrol_wallet/classes/payment/service_provider.php:**

public static function get_payable(string $paymentarea, int $itemid): \core_payment\local\entities\payable {
    global $DB, $USER;

    $item = $DB->get_record('enrol_wallet_items', ['id' => $itemid], '*', IGNORE_MISSING);

    if (!$item) {
        $bankitem = $DB->get_record('paygw_bank', ['itemid' => $itemid], '*', IGNORE_MISSING);
        if (!$bankitem) {
            // If both records are missing, return a default payable object
            $defaultcost = 0;
            $defaultcurrency = get_config('moodle', 'currency');
            $defaultaccount = get_config('enrol_wallet', 'paymentaccount');
            return new \core_payment\local\entities\payable($defaultcost, $defaultcurrency, $defaultaccount);
        }
        $item = new \stdClass();
        $item->cost = $bankitem->totalamount;
        $item->currency = $bankitem->currency;
        $item->instanceid = $bankitem->itemid;
    }

    // ... (rest of the method remains unchanged)
}

**Explanation:**

This change allows the wallet plugin to gracefully handle situations where payment records have been deleted from both the enrol_wallet_items and paygw_bank tables. By returning a default payable object instead of throwing an exception, we prevent errors in the bank payment gateway management interface.

2: Later I discovered another issue. This next change addresses an issue where the enrolment process was failing due to problems with event triggering. The changes improve error handling and ensure that the enrolment process completes successfully even if there are issues with event triggering.

**Code changes in lib.php:**

Added a try-catch block around the event triggering code:

```
try {
    // Trigger event for successful enrolment.
    $params = [
        'context'   => context_course::instance($instance->courseid),
        'objectid'  => $instance->id,
        'courseid'  => $instance->courseid,
        'relateduserid' => $user->id,
    ];
    $event = \core\event\user_enrolment_created::create($params);
    $event->trigger();
} catch (\Exception $e) {
    // Log the error but don't stop the enrolment process
    debugging('Error triggering enrolment event: ' . $e->getMessage(), DEBUG_DEVELOPER);
}
```

This change ensures that if there's an issue with creating or triggering the event, it won't prevent the user from being enrolled in the course.

The error is logged using the debugging function, which allows administrators to see if there are any issues with event triggering without disrupting the user experience.

The enrolment process now continues even if the event triggering fails, ensuring that users can still be enrolled in courses.

**Explanation:**

The previous implementation was causing enrolment failures when using paygw_bank due to issues with event triggering. This change improves the robustness of the wallet plugin by separating the core functionality (enrolling the user) from the auxiliary functionality (triggering events).

By catching exceptions related to event triggering, we ensure that temporary issues with the event system don't prevent users from enrolling in courses. This improves the overall reliability and user experience of the wallet plugin.

*PS. If you would like me to modify something, feel free to ask.*